### PR TITLE
Add token for Horizon (1080p) to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ If that doesn't work or couldn't find your projector in the table, see for more 
 |      Halo+     	| 143FCB9335F278FFFFFF3043524B544D 	|
 |      Elfin     	| 12D7C7899B9F80FFFFFF3043524B544D 	|
 | Horizon Pro 4K 	| 1A7E0C743AEF18FFFFFF3043524B544D 	|
-
+| Horizon (1080p) 	| 33D731E3B22440FFFFFF3043524B544D 	|
 
 
 


### PR DESCRIPTION
Firstly, thank you for writing this - it's saved me the massive headache of reverse engineering it myself.

As a _token_ of my appreciation, please accept the manufacturer data captured from my Horizon projector (the regular 1080p one). 

`33D731E3B22440FFFFFF3043524B544D`

Thanks!