### PR TITLE
fix & tool: enhancement for this integration 

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,30 @@ b. Linux terminal, use ``bluetoothctl`` in the terminal:
 Either with android app or with linux bluetoothctl, you should now able to poweron the projector without the remote.  
 [Here](https://github.com/manymuch/Xgimi-4-Home-Assistant/issues/5#issuecomment-1752887102) provides an alternative way to get the token without iOS or Android device.  
 
+#### A script tool for scanning BLE token
+this script is adapted from https://github.com/jack-webb/XBleet
+to use this script, you need to install dependency first
+```shell
+pip install bleak
+```
+
+and then 
+```shell
+python3 tool/scan.py
+```
+
+It will scan the bluetooth signals until you stop the script. And it only prints the result with manufacturer code == 0x46 (which is our target).
+A sample output looks like:
+```text
+Discovered BLE device(s):
+Discovered BLE device(s):
+Discovered BLE device(s):
+Discovered BLE device(s):
+Discovered BLE device(s):
+Device name: BLuetooth 4.0 RC, Address: 70:FD:88:CE:97:9E
+Manufacturer 0x46
+Data 0x5AC993202D314CFFFFFF3043524B544D
+```
 
 ### Choose a method to setup:  
 #### Method A: manual setup

--- a/custom_components/xgimi/pyxgimi.py
+++ b/custom_components/xgimi/pyxgimi.py
@@ -3,7 +3,7 @@ import asyncio
 from bluez_peripheral.util import get_message_bus
 from bluez_peripheral.advert import Advertisement
 from time import time
-
+import subprocess
 
 class XgimiApi:
     def __init__(self, ip, command_port, advance_port, alive_port, manufacturer_data) -> None:
@@ -65,13 +65,20 @@ class XgimiApi:
 
     async def async_check_alive(self):
         try:
-            _, writer = await asyncio.open_connection(
-                self.ip, self.alive_port)
-            writer.close()
-            await writer.wait_closed()
-            return True
-        except ConnectionRefusedError:
-            return False
+            # 使用 subprocess 模块执行 ping 命令
+            process = await asyncio.create_subprocess_shell(
+                f"ping -c 1 {self.ip}",  # -c 1 表示发送一次 ICMP 请求
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE
+            )
+
+            stdout, stderr = await process.communicate()
+
+            # 检查返回码来判断是否成功
+            if process.returncode == 0:
+                return True
+            else:
+                return False
         except Exception:
             return False
 

--- a/tools/scan.py
+++ b/tools/scan.py
@@ -1,0 +1,31 @@
+import asyncio
+import bleak
+
+async def print_device_info(device):
+    manufacturer_data = device.metadata.get("manufacturer_data", {})
+    if manufacturer_data:
+        for manufacturer_code, data in manufacturer_data.items():
+            if manufacturer_code != 70:
+                continue
+            print(f"Device name: {device.name}, Address: {device.address}")
+            hex_code = format(manufacturer_code, '02X')
+            hex_data = ''.join(format(byte, '02X') for byte in data)
+            print(f"Manufacturer 0x{hex_code}\nData 0x{hex_data}")
+
+async def scan_for_ble_devices():
+    devices = await bleak.discover()
+    if devices:
+        print("Discovered BLE device(s):")
+        for device in devices:
+            await print_device_info(device)
+    else:
+        print("No BLE devices found nearby.")
+
+async def loop_scan():
+    while True:
+        await scan_for_ble_devices()
+
+if __name__ == "__main__":
+    loop = asyncio.get_event_loop()
+    loop.run_until_complete(loop_scan())
+    #loop.run_until_complete(scan_for_ble_devices())


### PR DESCRIPTION
1. In 2024/09/21, my Z7X projector is no longer listening on port 554, so the method I used to check its status is no longer working. I have scanned all the ports on my projector. Here is the result from nmap:
```text
PORT     STATE SERVICE        VERSION
7001/tcp open  afs3-callback?
7002/tcp open  afs3-prserver?
7100/tcp open  font-service?
8080/tcp open  http-proxy?
```
I also found that when the projector is on, I can see its IP address in the router. This IP address disappears when the projector is off. Therefore, another way to detect the projector's status is by using the ping method.

2. I added a script tool for scanning BLE tokens; this simplifies the process of finding tokens.

I hope these corrections help clarify your message. If you need further assistance, feel free to ask!